### PR TITLE
Normalize bootstrap line endings in Dockerfiles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-run-simulation-lambda/bootstrap text eol=lf
-generate-report-lambda/bootstrap text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+run-simulation-lambda/bootstrap text eol=lf
+generate-report-lambda/bootstrap text eol=lf

--- a/generate-report-lambda/Dockerfile
+++ b/generate-report-lambda/Dockerfile
@@ -33,9 +33,8 @@ ENV PATH="${LAMBDA_TASK_ROOT}/.venv/bin:$PATH"
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
 RUN chmod 755 /usr/bin/aws-lambda-rie
 
-# Copy bootstrap and normalize line endings (Windows CRLF -> LF) then make executable
 COPY bootstrap /var/runtime/bootstrap
-RUN sed -i 's/\r$//' /var/runtime/bootstrap && chmod 755 /var/runtime/bootstrap
+RUN chmod 755 /var/runtime/bootstrap
 
 # Enable Python to find packages in the virtual environment
 ENV PYTHONPATH="${LAMBDA_TASK_ROOT}/.venv/lib/python3.12/site-packages:${LAMBDA_TASK_ROOT}:${LAMBDA_TASK_ROOT}/src:${PYTHONPATH}"

--- a/generate-report-lambda/Dockerfile
+++ b/generate-report-lambda/Dockerfile
@@ -33,8 +33,9 @@ ENV PATH="${LAMBDA_TASK_ROOT}/.venv/bin:$PATH"
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
 RUN chmod 755 /usr/bin/aws-lambda-rie
 
+# Copy bootstrap and normalize line endings (Windows CRLF -> LF) then make executable
 COPY bootstrap /var/runtime/bootstrap
-RUN chmod 755 /var/runtime/bootstrap
+RUN sed -i 's/\r$//' /var/runtime/bootstrap && chmod 755 /var/runtime/bootstrap
 
 # Enable Python to find packages in the virtual environment
 ENV PYTHONPATH="${LAMBDA_TASK_ROOT}/.venv/lib/python3.12/site-packages:${LAMBDA_TASK_ROOT}:${LAMBDA_TASK_ROOT}/src:${PYTHONPATH}"

--- a/run-simulation-lambda/Dockerfile
+++ b/run-simulation-lambda/Dockerfile
@@ -33,9 +33,8 @@ ENV PATH="${LAMBDA_TASK_ROOT}/.venv/bin:$PATH"
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
 RUN chmod 755 /usr/bin/aws-lambda-rie
 
-# Copy bootstrap and normalize line endings (Windows CRLF -> LF) then make executable
 COPY bootstrap /var/runtime/bootstrap
-RUN sed -i 's/\r$//' /var/runtime/bootstrap && chmod 755 /var/runtime/bootstrap
+RUN chmod 755 /var/runtime/bootstrap
 
 # Enable Python to find packages in the virtual environment
 ENV PYTHONPATH="${LAMBDA_TASK_ROOT}/.venv/lib/python3.12/site-packages:${LAMBDA_TASK_ROOT}:${LAMBDA_TASK_ROOT}/src:${PYTHONPATH}"

--- a/run-simulation-lambda/Dockerfile
+++ b/run-simulation-lambda/Dockerfile
@@ -33,8 +33,9 @@ ENV PATH="${LAMBDA_TASK_ROOT}/.venv/bin:$PATH"
 ADD https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie /usr/bin/aws-lambda-rie
 RUN chmod 755 /usr/bin/aws-lambda-rie
 
+# Copy bootstrap and normalize line endings (Windows CRLF -> LF) then make executable
 COPY bootstrap /var/runtime/bootstrap
-RUN chmod 755 /var/runtime/bootstrap
+RUN sed -i 's/\r$//' /var/runtime/bootstrap && chmod 755 /var/runtime/bootstrap
 
 # Enable Python to find packages in the virtual environment
 ENV PYTHONPATH="${LAMBDA_TASK_ROOT}/.venv/lib/python3.12/site-packages:${LAMBDA_TASK_ROOT}:${LAMBDA_TASK_ROOT}/src:${PYTHONPATH}"


### PR DESCRIPTION
Updated Dockerfiles for both Lambda functions to convert Windows CRLF to LF in the bootstrap script before setting executable permissions. Added .gitattributes entries to enforce LF line endings for bootstrap files.